### PR TITLE
4.x Allow for color interface to be used in color

### DIFF
--- a/packages/forms/resources/js/components/file-upload.js
+++ b/packages/forms/resources/js/components/file-upload.js
@@ -247,7 +247,7 @@ export default function fileUploadFormComponent({
                     .map((file) =>
                         file.source instanceof File
                             ? file.serverId
-                            : this.uploadedFileIndex[file.source] ?? null,
+                            : (this.uploadedFileIndex[file.source] ?? null),
                     ) // file.serverId is null for a file that is not yet uploaded
                     .filter((fileKey) => fileKey)
 

--- a/packages/infolists/src/Components/Concerns/HasColor.php
+++ b/packages/infolists/src/Components/Concerns/HasColor.php
@@ -62,14 +62,14 @@ trait HasColor
             return null;
         }
 
+        if ($color instanceof ColorInterface) {
+            return $color->getColor();
+        }
+
         if (filled($color)) {
             return $color;
         }
 
-        if (! $state instanceof ColorInterface) {
-            return null;
-        }
-
-        return $state->getColor();
+        return null;
     }
 }

--- a/packages/panels/resources/views/components/unsaved-action-changes-alert.blade.php
+++ b/packages/panels/resources/views/components/unsaved-action-changes-alert.blade.php
@@ -7,7 +7,7 @@
                 }
 
                 if (
-                    (@js($this instanceof \Filament\Actions\Contracts\HasActions) ? $wire.mountedActions?.length ?? 0 : 0) &&
+                    (@js($this instanceof \Filament\Actions\Contracts\HasActions) ? ($wire.mountedActions?.length ?? 0) : 0) &&
                     !$wire?.__instance?.effects?.redirect
                 ) {
                     event.preventDefault()

--- a/packages/support/src/Concerns/HasColor.php
+++ b/packages/support/src/Concerns/HasColor.php
@@ -3,6 +3,7 @@
 namespace Filament\Support\Concerns;
 
 use Closure;
+use Filament\Support\Contracts\HasColor as ColorInterface;
 
 trait HasColor
 {
@@ -41,6 +42,16 @@ trait HasColor
      */
     public function getColor(): string | array | null
     {
-        return $this->evaluate($this->color) ?? $this->evaluate($this->defaultColor);
+        $color = $this->evaluate($this->color) ?? $this->evaluate($this->defaultColor);
+
+        if ($color instanceof ColorInterface) {
+            return $color->getColor();
+        }
+
+        if (filled($color)) {
+            return $color;
+        }
+
+        return null;
     }
 }

--- a/packages/tables/src/Columns/Concerns/HasColor.php
+++ b/packages/tables/src/Columns/Concerns/HasColor.php
@@ -62,14 +62,14 @@ trait HasColor
             return null;
         }
 
-        if ($color instanceof ColorInterface) {
-            return $color->getColor();
-        }
-
         if (filled($color)) {
             return $color;
         }
 
-        return null;
+        if (! $state instanceof ColorInterface) {
+            return null;
+        }
+
+        return $state->getColor();
     }
 }

--- a/packages/tables/src/Columns/Concerns/HasColor.php
+++ b/packages/tables/src/Columns/Concerns/HasColor.php
@@ -62,14 +62,14 @@ trait HasColor
             return null;
         }
 
+        if ($color instanceof ColorInterface) {
+            return $color->getColor();
+        }
+
         if (filled($color)) {
             return $color;
         }
 
-        if (! $state instanceof ColorInterface) {
-            return null;
-        }
-
-        return $state->getColor();
+        return null;
     }
 }

--- a/packages/tables/src/Filters/SelectFilter.php
+++ b/packages/tables/src/Filters/SelectFilter.php
@@ -216,7 +216,7 @@ class SelectFilter extends BaseFilter
     }
 
     /**
-     * @param bool | array<string> | Closure $condition
+     * @param  bool | array<string> | Closure  $condition
      */
     public function searchable(bool | array | Closure $condition = true): static
     {

--- a/tests/src/Tables/Fixtures/ColorEnum.php
+++ b/tests/src/Tables/Fixtures/ColorEnum.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Filament\Tests\Tables\Fixtures;
+
+use Filament\Support\Colors\Color;
+use Filament\Support\Contracts\HasColor as ColorInterface;
+
+enum ColorEnum implements ColorInterface
+{
+    case Red;
+
+    public function getColor(): string | array | null
+    {
+        return match ($this) {
+            self::Red => Color::Red,
+        };
+    }
+}

--- a/tests/src/Tables/Fixtures/PostsTable.php
+++ b/tests/src/Tables/Fixtures/PostsTable.php
@@ -98,6 +98,8 @@ class PostsTable extends Component implements HasActions, HasForms, Tables\Contr
                         'red' => 'Red',
                         'blue' => 'Blue',
                     ]),
+                Tables\Columns\TextColumn::make('colour_red')
+                    ->color(fn (): ColorEnum => ColorEnum::Red),
                 Tables\Columns\TextColumn::make('title2')
                     ->sortable()
                     ->searchable()
@@ -157,6 +159,8 @@ class PostsTable extends Component implements HasActions, HasForms, Tables\Contr
                     ->label('My Action'),
                 Action::make('hasColor')
                     ->color('primary'),
+                Action::make('hasEnumColor')
+                    ->color(fn () => ColorEnum::Red),
                 Action::make('exists'),
                 Action::make('existsInOrder'),
                 Action::make('url')


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description
Allow for Enum with ColorInterface to be returned from closure.

```php
TextColumn::make()
   ->color(fn (?string $state): FilamentColorEnum => $state ? ColorEnum::Success : ColorEnum::Danger)

Action::make('hasEnumColor')
    ->color(fn () => ColorEnum::Danger),
```


```php
use Filament\Support\Colors\Color;
use Filament\Support\Contracts\HasColor as ColorInterface;

enum ColorEnum: string implements ColorInterface
{
    case Danger = 'danger';
    case Success = 'success';

    public function getColor(): string|array|null
    {
        return match ($this) {
            self::Danger => Color::Red,
            self::Success => Color::Green,
        };
    }
}
```

Example


## Visual changes

Without this change it always entered the `filled` if statement. 
<img width="1407" alt="Screenshot 2024-09-24 at 20 02 41" src="https://github.com/user-attachments/assets/8e439c96-8ca3-4dc3-94f1-090f64a159c5">


## Functional changes

- [x] Code style has been fixed by running the `composer cs` command.
- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.
